### PR TITLE
fix: sync middle project when category is tagged

### DIFF
--- a/src/hooks/useProjects.js
+++ b/src/hooks/useProjects.js
@@ -96,7 +96,8 @@ function useProjects(categoryId) {
       .then(_project => {
         setProjects(newProjects => {
           const targetProject = newProjects.find(project => project.id.toString() === projectId);
-          Object.assign(targetProject, _project);
+          if (targetProject)
+            Object.assign(targetProject, _project);
           return [...newProjects]
         });
       })


### PR DESCRIPTION
开始一个蕃茄后， 如果切换了分类，那么蕃茄完成后， 在更新中间项目区域的蕃茄数的时候可能会报错。